### PR TITLE
fix: use Authorization header instead of x-api-key

### DIFF
--- a/bots/calendar-bot.ts
+++ b/bots/calendar-bot.ts
@@ -191,7 +191,7 @@ export async function createEvent(
       headers: {
         'Content-Type': 'application/json',
         [TENANT_HEADER]: TENANT,
-        'x-api-key': config.delphiApi.calendarApiKey,
+        Authorization: `Bearer ${config.delphiApi.calendarApiKey}`,
       },
       body: JSON.stringify(body),
     });


### PR DESCRIPTION
## Summary
- Switch from `x-api-key` to `Authorization: Bearer <key>` header when calling Hydra's bot event creation endpoint
- CloudFront strips custom headers that aren't whitelisted — `Authorization` is already allowed

## Dependency
**Must deploy after** [hydra#823](https://github.com/delphidigital/hydra/pull/823) is merged (Hydra side of the same fix)

## Test plan
- [x] All 30 bot tests pass
- [ ] After both PRs deploy: test `/addevent` on @DelphiCalenderBot — event creation should succeed (no more 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)