### PR TITLE
fix: split DELPHI_API_BASE_URL into separate vars per bot

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,6 +7,7 @@ DELPHI_AF_API_KEY=
 OPENAI_API_KEY=
 
 # Calendar Bot (optional - set all three to enable)
+HYDRA_API_BASE_URL=  # e.g. https://api.hydra.platform.delphidigital.io — overrides DELPHI_API_BASE_URL for calendar bot
 CALENDAR_BOT_TOKEN=
 CALENDAR_WEBHOOK_URL=
 CALENDAR_API_KEY=

--- a/server.ts
+++ b/server.ts
@@ -19,6 +19,7 @@ const {
   DELPHI_READS_READING_LIST_ID,
   OPENAI_API_KEY,
   // Calendar bot env vars
+  HYDRA_API_BASE_URL,
   CALENDAR_BOT_TOKEN,
   CALENDAR_WEBHOOK_URL,
   CALENDAR_API_KEY,
@@ -59,14 +60,14 @@ console.log('Reads Bot Configuration:', {
 
 // ==================== Calendar Bot ====================
 
-const calendarBotEnabled = !!(CALENDAR_BOT_TOKEN && CALENDAR_API_KEY && (DEV || CALENDAR_WEBHOOK_URL));
+const calendarBotEnabled = !!(HYDRA_API_BASE_URL && CALENDAR_BOT_TOKEN && CALENDAR_API_KEY && (DEV || CALENDAR_WEBHOOK_URL));
 let calBot: ReturnType<typeof calendarBot> | null = null;
 
 if (calendarBotEnabled) {
   const calendarBotConfig: CalendarBotConfig = {
     botToken: CALENDAR_BOT_TOKEN,
     delphiApi: {
-      baseUrl: DELPHI_API_BASE_URL,
+      baseUrl: HYDRA_API_BASE_URL,
       calendarApiKey: CALENDAR_API_KEY,
     },
   };
@@ -74,12 +75,14 @@ if (calendarBotEnabled) {
   calBot = calendarBot(calendarBotConfig);
 
   console.log('Calendar Bot Configuration:', {
+    HYDRA_API_BASE_URL,
     CALENDAR_WEBHOOK_URL,
     CALENDAR_BOT_TOKEN: mask(CALENDAR_BOT_TOKEN),
     CALENDAR_API_KEY: mask(CALENDAR_API_KEY),
   });
 } else {
   const missing: string[] = [];
+  if (!HYDRA_API_BASE_URL) missing.push('HYDRA_API_BASE_URL');
   if (!CALENDAR_BOT_TOKEN) missing.push('CALENDAR_BOT_TOKEN');
   if (!CALENDAR_API_KEY) missing.push('CALENDAR_API_KEY');
   if (!DEV && !CALENDAR_WEBHOOK_URL) missing.push('CALENDAR_WEBHOOK_URL');


### PR DESCRIPTION
## Summary
- Adds `HYDRA_API_BASE_URL` as a dedicated env var for the calendar bot (Hydra)
- Calendar bot no longer shares `DELPHI_API_BASE_URL` with the reads/clerk bot (members portal)
- Calendar bot is only enabled when `HYDRA_API_BASE_URL` is set — no silent fallback to wrong URL

## Root Cause
Both bots shared `DELPHI_API_BASE_URL` but need different base URLs. Pointing it at Hydra for the calendar bot broke the reads bot and 3 other things in prod.

## Deploy Step
After merging, set the Fly secret:
```
fly secrets set HYDRA_API_BASE_URL=https://api.hydra.platform.delphidigital.io --app delphi-tg-bots-prod
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)