### PR TITLE
feat: hot list /hotlist command + weekly digest block (Phase 1)

### DIFF
--- a/bots/calendar-bot.ts
+++ b/bots/calendar-bot.ts
@@ -177,8 +177,11 @@ export async function fetchHotEvents(
   const today = new Date().toISOString().split('T')[0];
   const endDate = new Date(Date.now() + days * 86400000).toISOString().split('T')[0];
 
+  // Soft cap on the curator side is 7 (see calendar-web /admin/hot-list);
+  // 20 matches /upcoming and gives plenty of headroom while still bounding
+  // payload size for very long curator runs.
   const url = apiUrl(
-    `/api/v1/calendar/events?start_date=${today}&end_date=${endDate}&status=published&is_hot=true&limit=10`,
+    `/api/v1/calendar/events?start_date=${today}&end_date=${endDate}&status=published&is_hot=true&limit=20`,
     config
   );
 
@@ -327,10 +330,16 @@ export function calendarBot(config: CalendarBotConfig): Telegraf<CalendarContext
       return;
     }
 
-    await ctx.reply(`${block}\n\nWas this useful?`, {
-      parse_mode: 'HTML',
-      ...hotFeedbackKeyboard(),
-    });
+    // Chunk under Telegram's 4096-char limit. Attach the feedback keyboard
+    // only to the last chunk so the buttons don't appear mid-thread.
+    const chunks = chunkForTelegram(`${block}\n\nWas this useful?`);
+    for (const [index, chunk] of chunks.entries()) {
+      const isLast = index === chunks.length - 1;
+      await ctx.reply(chunk, {
+        parse_mode: 'HTML',
+        ...(isLast ? hotFeedbackKeyboard() : {}),
+      });
+    }
   });
 
   // ==================== /categories ====================
@@ -707,21 +716,42 @@ export function hotFeedbackKeyboard() {
 
 /**
  * Telegram has a 4096-char limit per message. Split a long digest on newlines
- * so each chunk stays under 4000 chars without breaking HTML tags mid-line.
+ * first (preserves formatting), then hard-split any single line longer than
+ * `maxLen` on character boundaries as a fallback. Hard-splitting can break
+ * HTML tags mid-line, but our digest lines come from validated event fields
+ * (≤500 chars) so this only fires on pathological input.
  */
 export function chunkForTelegram(message: string, maxLen = 4000): string[] {
   if (message.length <= maxLen) return [message];
 
   const chunks: string[] = [];
   let current = '';
+
+  const flush = () => {
+    if (current) {
+      chunks.push(current);
+      current = '';
+    }
+  };
+
   for (const line of message.split('\n')) {
+    if (line.length > maxLen) {
+      // Single line longer than the limit — flush whatever's pending, then
+      // hard-split the line into bounded pieces.
+      flush();
+      for (let i = 0; i < line.length; i += maxLen) {
+        chunks.push(line.slice(i, i + maxLen));
+      }
+      continue;
+    }
+
     if (current.length + line.length + 1 > maxLen) {
-      if (current) chunks.push(current);
+      flush();
       current = line;
     } else {
       current += (current ? '\n' : '') + line;
     }
   }
-  if (current) chunks.push(current);
+  flush();
   return chunks;
 }

--- a/bots/calendar-bot.ts
+++ b/bots/calendar-bot.ts
@@ -266,6 +266,7 @@ export function calendarBot(config: CalendarBotConfig): Telegraf<CalendarContext
         'I can help you manage crypto calendar events.\n\n' +
         'Available commands:\n' +
         '/upcoming - View upcoming events (next 7 days)\n' +
+        '/hotlist - Preview curator-flagged hot picks\n' +
         '/addevent - Create a new calendar event\n' +
         '/categories - List event categories\n' +
         '/help - Show this help message\n' +
@@ -278,6 +279,7 @@ export function calendarBot(config: CalendarBotConfig): Telegraf<CalendarContext
     await ctx.reply(
       '📅 <b>Delphi Calendar Bot Commands</b>\n\n' +
         '/upcoming - View upcoming events (next 7 days)\n' +
+        '/hotlist - Preview curator-flagged hot picks\n' +
         '/addevent - Create a new calendar event\n' +
         '/categories - List event categories\n' +
         '/cancel - Cancel current operation\n' +
@@ -297,49 +299,12 @@ export function calendarBot(config: CalendarBotConfig): Telegraf<CalendarContext
   bot.command('upcoming', async (ctx) => {
     await ctx.reply('⏳ Fetching upcoming events...');
 
-    const { events, total } = await fetchUpcomingEvents(config);
-
-    if (events.length === 0) {
-      await ctx.reply('📅 No upcoming events in the next 7 days.');
-      return;
-    }
-
-    let message = '📅 <b>Upcoming Events (Next 7 Days)</b>\n━━━━━━━━━━━━━━━━━━━\n';
-
-    for (const event of events) {
-      const category = event.category?.name || 'Uncategorized';
-      const time = event.time ? ` • ${formatTime(event.time)}` : '';
-      const endDate = event.end_date && event.end_date !== event.date
-        ? ` – ${formatDate(event.end_date)}`
-        : '';
-      const link = event.link ? `\n   🔗 ${escapeHtml(event.link)}` : '';
-
-      message +=
-        `\n📌 <b>${escapeHtml(event.name)}</b>\n` +
-        `   ${formatDate(event.date)}${endDate}${time}\n` +
-        `   🏷 ${escapeHtml(category)}${link}\n`;
-    }
-
-    const shown = events.length;
-    const footer = shown < total
-      ? `📊 Showing ${shown} of ${total} events`
-      : `📊 ${total} event${total === 1 ? '' : 's'} total`;
-    message += `\n━━━━━━━━━━━━━━━━━━━\n${footer}`;
+    const response = await fetchUpcomingEvents(config);
+    const message = formatWeeklyDigest(response);
 
     // Telegram has a 4096 char limit per message
     if (message.length > 4000) {
-      const chunks: string[] = [];
-      let current = '';
-      for (const line of message.split('\n')) {
-        if (current.length + line.length + 1 > 4000) {
-          chunks.push(current);
-          current = line;
-        } else {
-          current += (current ? '\n' : '') + line;
-        }
-      }
-      if (current) chunks.push(current);
-      for (const chunk of chunks) {
+      for (const chunk of chunkForTelegram(message)) {
         await ctx.reply(chunk, { parse_mode: 'HTML' });
       }
     } else {
@@ -416,17 +381,30 @@ export function calendarBot(config: CalendarBotConfig): Telegraf<CalendarContext
     const data = 'data' in ctx.callbackQuery ? ctx.callbackQuery.data : undefined;
     if (!data) return;
 
-    // Hot-list feedback: log for prompt iteration in Stage 2/3, ack to user.
-    // Acked before any other branches so the toast feedback is snappy.
-    if (data === 'hot_feedback_up' || data === 'hot_feedback_down') {
+    // Hot-list feedback: structured callback `hot_feedback:<verdict>` so a
+    // future Stage 2/3 rollup can grep [hot_feedback] log lines for verdict
+    // counts. Phase 1 is block-level (one rating per digest message); per-
+    // event scoring will be added when we have engagement signal to tune on.
+    if (data.startsWith('hot_feedback:')) {
+      const verdict = data.slice('hot_feedback:'.length);
+      const knownVerdict = verdict === 'helpful' || verdict === 'not_useful';
       const username = ctx.callbackQuery.from?.username || ctx.callbackQuery.from?.id || 'unknown';
-      const verdict = data === 'hot_feedback_up' ? 'helpful' : 'not_useful';
-      console.info(
-        `[hot_feedback] user=${username} verdict=${verdict} message_id=${ctx.callbackQuery.message?.message_id ?? 'unknown'}`
-      );
-      await ctx.answerCbQuery(
-        verdict === 'helpful' ? '🙏 Thanks for the signal!' : 'Got it — we’ll tune the picks.'
-      );
+      const messageId = ctx.callbackQuery.message?.message_id ?? 'unknown';
+
+      if (knownVerdict) {
+        console.info(
+          `[hot_feedback] user=${username} verdict=${verdict} message_id=${messageId}`
+        );
+        await ctx.answerCbQuery(
+          verdict === 'helpful' ? '🙏 Thanks for the signal!' : 'Got it — we’ll tune the picks.'
+        );
+      } else {
+        // Future-proof: ack but log so we notice if the keyboard format drifts.
+        console.warn(
+          `[hot_feedback] unknown verdict=${verdict} user=${username} message_id=${messageId}`
+        );
+        await ctx.answerCbQuery();
+      }
       return;
     }
 
@@ -713,14 +691,37 @@ export function formatWeeklyDigest(response: EventsApiResponse): string {
 
 /**
  * Inline keyboard prompting digest readers to react. Callback data is
- * `hot_feedback_up` / `hot_feedback_down`; the bot's callback_query handler
- * logs these for prompt iteration before Stage 2 automation.
+ * `hot_feedback:helpful` / `hot_feedback:not_useful` — the prefix lets the
+ * callback handler dispatch generically and lets future iterations append
+ * an event id (`hot_feedback:<verdict>:<event_id>`) without a breaking
+ * change.
  */
 export function hotFeedbackKeyboard() {
   return Markup.inlineKeyboard([
     [
-      Markup.button.callback('👍 Helpful', 'hot_feedback_up'),
-      Markup.button.callback('👎 Not useful', 'hot_feedback_down'),
+      Markup.button.callback('👍 Helpful', 'hot_feedback:helpful'),
+      Markup.button.callback('👎 Not useful', 'hot_feedback:not_useful'),
     ],
   ]);
+}
+
+/**
+ * Telegram has a 4096-char limit per message. Split a long digest on newlines
+ * so each chunk stays under 4000 chars without breaking HTML tags mid-line.
+ */
+export function chunkForTelegram(message: string, maxLen = 4000): string[] {
+  if (message.length <= maxLen) return [message];
+
+  const chunks: string[] = [];
+  let current = '';
+  for (const line of message.split('\n')) {
+    if (current.length + line.length + 1 > maxLen) {
+      if (current) chunks.push(current);
+      current = line;
+    } else {
+      current += (current ? '\n' : '') + line;
+    }
+  }
+  if (current) chunks.push(current);
+  return chunks;
 }

--- a/bots/calendar-bot.ts
+++ b/bots/calendar-bot.ts
@@ -128,17 +128,22 @@ export async function fetchCategories(config: CalendarBotConfig): Promise<Calend
 }
 
 interface EventsApiResponse {
-  events: Array<{
-    id: string;
-    name: string;
-    date: string;
-    time: string | null;
-    end_date: string | null;
-    description: string | null;
-    link: string | null;
-    category: { name: string; slug: string } | null;
-  }>;
+  events: CalendarEventResponse[];
   total: number;
+}
+
+export interface CalendarEventResponse {
+  id: string;
+  name: string;
+  date: string;
+  time: string | null;
+  end_date: string | null;
+  description: string | null;
+  link: string | null;
+  category: { name: string; slug: string } | null;
+  is_hot?: boolean;
+  hot_reason?: string | null;
+  hot_source?: string | null;
 }
 
 export async function fetchUpcomingEvents(
@@ -161,6 +166,30 @@ export async function fetchUpcomingEvents(
     return (await response.json()) as EventsApiResponse;
   } catch (error) {
     console.error('Failed to fetch upcoming events:', error);
+    return { events: [], total: 0 };
+  }
+}
+
+export async function fetchHotEvents(
+  config: CalendarBotConfig,
+  days: number = 7
+): Promise<EventsApiResponse> {
+  const today = new Date().toISOString().split('T')[0];
+  const endDate = new Date(Date.now() + days * 86400000).toISOString().split('T')[0];
+
+  const url = apiUrl(
+    `/api/v1/calendar/events?start_date=${today}&end_date=${endDate}&status=published&is_hot=true&limit=10`,
+    config
+  );
+
+  try {
+    const response = await fetch(url, {
+      headers: { [TENANT_HEADER]: TENANT },
+    });
+    if (!response.ok) throw new Error(`API returned ${response.status}`);
+    return (await response.json()) as EventsApiResponse;
+  } catch (error) {
+    console.error('Failed to fetch hot events:', error);
     return { events: [], total: 0 };
   }
 }
@@ -318,6 +347,27 @@ export function calendarBot(config: CalendarBotConfig): Telegraf<CalendarContext
     }
   });
 
+  // ==================== /hotlist ====================
+  // Standalone preview of the hot block + feedback prompt. Same content the
+  // weekly digest uses, useful for ad-hoc curator/QA checks before the digest
+  // sends to the broader Delphi research chat.
+  bot.command('hotlist', async (ctx) => {
+    await ctx.reply('⏳ Fetching hot events...');
+
+    const { events } = await fetchHotEvents(config);
+    const block = formatHotListBlock(events);
+
+    if (!block) {
+      await ctx.reply('🔥 No hot events flagged for the next 7 days.');
+      return;
+    }
+
+    await ctx.reply(`${block}\n\nWas this useful?`, {
+      parse_mode: 'HTML',
+      ...hotFeedbackKeyboard(),
+    });
+  });
+
   // ==================== /categories ====================
 
   bot.command('categories', async (ctx) => {
@@ -365,6 +415,20 @@ export function calendarBot(config: CalendarBotConfig): Telegraf<CalendarContext
   bot.on('callback_query', async (ctx) => {
     const data = 'data' in ctx.callbackQuery ? ctx.callbackQuery.data : undefined;
     if (!data) return;
+
+    // Hot-list feedback: log for prompt iteration in Stage 2/3, ack to user.
+    // Acked before any other branches so the toast feedback is snappy.
+    if (data === 'hot_feedback_up' || data === 'hot_feedback_down') {
+      const username = ctx.callbackQuery.from?.username || ctx.callbackQuery.from?.id || 'unknown';
+      const verdict = data === 'hot_feedback_up' ? 'helpful' : 'not_useful';
+      console.info(
+        `[hot_feedback] user=${username} verdict=${verdict} message_id=${ctx.callbackQuery.message?.message_id ?? 'unknown'}`
+      );
+      await ctx.answerCbQuery(
+        verdict === 'helpful' ? '🙏 Thanks for the signal!' : 'Got it — we’ll tune the picks.'
+      );
+      return;
+    }
 
     await ctx.answerCbQuery();
 
@@ -575,4 +639,88 @@ export function escapeHtml(text: string): string {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
+}
+
+// ==================== Hot list (Phase 1) ====================
+
+/**
+ * Format the hot-list block that sits at the top of the weekly digest and
+ * the /hotlist command response. Returns null when there's nothing to show
+ * so callers can skip the section without leaving stray headers.
+ */
+export function formatHotListBlock(events: CalendarEventResponse[]): string | null {
+  const hot = events.filter(e => e.is_hot);
+  if (hot.length === 0) return null;
+
+  const lines = ['🔥 <b>Hot this week</b>'];
+  for (const event of hot) {
+    const time = event.time ? ` · ${formatTime(event.time)}` : '';
+    const reason = event.hot_reason ? ` — ${escapeHtml(event.hot_reason)}` : '';
+    lines.push(
+      `• <b>${escapeHtml(event.name)}</b> (${formatDate(event.date)}${time})${reason}`
+    );
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Build the full weekly digest message: hot block + standard upcoming list.
+ * Pure function over the API response so it's easy to unit-test without a
+ * Telegram client.
+ */
+export function formatWeeklyDigest(response: EventsApiResponse): string {
+  const { events, total } = response;
+  const hotBlock = formatHotListBlock(events);
+
+  if (events.length === 0) {
+    return '📅 No upcoming events in the next 7 days.';
+  }
+
+  const sections: string[] = [];
+  if (hotBlock) {
+    sections.push(hotBlock);
+    sections.push('━━━━━━━━━━━━━━━━━━━');
+  }
+
+  sections.push('📅 <b>Upcoming Events (Next 7 Days)</b>');
+  sections.push('━━━━━━━━━━━━━━━━━━━');
+
+  for (const event of events) {
+    const category = event.category?.name || 'Uncategorized';
+    const time = event.time ? ` • ${formatTime(event.time)}` : '';
+    const endDate = event.end_date && event.end_date !== event.date
+      ? ` – ${formatDate(event.end_date)}`
+      : '';
+    const link = event.link ? `\n   🔗 ${escapeHtml(event.link)}` : '';
+    const flame = event.is_hot ? '🔥 ' : '';
+
+    sections.push(
+      `\n${flame}📌 <b>${escapeHtml(event.name)}</b>\n` +
+        `   ${formatDate(event.date)}${endDate}${time}\n` +
+        `   🏷 ${escapeHtml(category)}${link}`
+    );
+  }
+
+  const shown = events.length;
+  const footer = shown < total
+    ? `📊 Showing ${shown} of ${total} events`
+    : `📊 ${total} event${total === 1 ? '' : 's'} total`;
+  sections.push('\n━━━━━━━━━━━━━━━━━━━');
+  sections.push(footer);
+
+  return sections.join('\n');
+}
+
+/**
+ * Inline keyboard prompting digest readers to react. Callback data is
+ * `hot_feedback_up` / `hot_feedback_down`; the bot's callback_query handler
+ * logs these for prompt iteration before Stage 2 automation.
+ */
+export function hotFeedbackKeyboard() {
+  return Markup.inlineKeyboard([
+    [
+      Markup.button.callback('👍 Helpful', 'hot_feedback_up'),
+      Markup.button.callback('👎 Not useful', 'hot_feedback_down'),
+    ],
+  ]);
 }

--- a/bots/calendar-bot.ts
+++ b/bots/calendar-bot.ts
@@ -395,14 +395,14 @@ export function calendarBot(config: CalendarBotConfig): Telegraf<CalendarContext
     // counts. Phase 1 is block-level (one rating per digest message); per-
     // event scoring will be added when we have engagement signal to tune on.
     if (data.startsWith('hot_feedback:')) {
-      const verdict = data.slice('hot_feedback:'.length);
-      const knownVerdict = verdict === 'helpful' || verdict === 'not_useful';
+      const { verdict, eventId, known } = parseHotFeedback(data);
       const username = ctx.callbackQuery.from?.username || ctx.callbackQuery.from?.id || 'unknown';
       const messageId = ctx.callbackQuery.message?.message_id ?? 'unknown';
+      const eventTag = eventId ? ` event=${eventId}` : '';
 
-      if (knownVerdict) {
+      if (known) {
         console.info(
-          `[hot_feedback] user=${username} verdict=${verdict} message_id=${messageId}`
+          `[hot_feedback] user=${username} verdict=${verdict}${eventTag} message_id=${messageId}`
         );
         await ctx.answerCbQuery(
           verdict === 'helpful' ? '🙏 Thanks for the signal!' : 'Got it — we’ll tune the picks.'
@@ -410,7 +410,7 @@ export function calendarBot(config: CalendarBotConfig): Telegraf<CalendarContext
       } else {
         // Future-proof: ack but log so we notice if the keyboard format drifts.
         console.warn(
-          `[hot_feedback] unknown verdict=${verdict} user=${username} message_id=${messageId}`
+          `[hot_feedback] unknown verdict=${verdict}${eventTag} user=${username} message_id=${messageId}`
         );
         await ctx.answerCbQuery();
       }
@@ -699,6 +699,28 @@ export function formatWeeklyDigest(response: EventsApiResponse): string {
 }
 
 /**
+ * Parse the `hot_feedback:<verdict>[:<event_id>]` callback payload. The
+ * keyboard today emits just `<verdict>`; a future iteration may suffix
+ * `<event_id>` for per-event scoring. Splitting here keeps the callback
+ * handler stable across that change.
+ */
+export type HotFeedbackPayload = {
+  verdict: string;
+  eventId?: string;
+  known: boolean;
+};
+
+export function parseHotFeedback(data: string): HotFeedbackPayload {
+  const prefix = 'hot_feedback:';
+  if (!data.startsWith(prefix)) {
+    return { verdict: '', known: false };
+  }
+  const [verdict, eventId] = data.slice(prefix.length).split(':');
+  const known = verdict === 'helpful' || verdict === 'not_useful';
+  return { verdict, eventId, known };
+}
+
+/**
  * Inline keyboard prompting digest readers to react. Callback data is
  * `hot_feedback:helpful` / `hot_feedback:not_useful` — the prefix lets the
  * callback handler dispatch generically and lets future iterations append
@@ -715,22 +737,28 @@ export function hotFeedbackKeyboard() {
 }
 
 /**
- * Telegram has a 4096-char limit per message. Split a long digest on newlines
- * first (preserves formatting), then hard-split any single line longer than
- * `maxLen` on character boundaries as a fallback. Hard-splitting can break
- * HTML tags mid-line, but our digest lines come from validated event fields
- * (≤500 chars) so this only fires on pathological input.
+ * Telegram has a 4096-char limit per message. Split a long message on
+ * newlines first (preserves formatting), then hard-split any single line
+ * longer than `maxLen` on character boundaries as a fallback.
+ *
+ * Contract: `chunks.join('\n') === message` for any input where no single
+ * line exceeds `maxLen`. (When hard-splitting fires, that contract relaxes
+ * — but our digest lines come from validated event fields ≤500 chars, so
+ * the fallback only fires on pathological input.)
+ *
+ * Uses `null` to distinguish "no current chunk yet" from "current chunk is
+ * an empty string", so leading/boundary blank lines round-trip correctly.
  */
 export function chunkForTelegram(message: string, maxLen = 4000): string[] {
   if (message.length <= maxLen) return [message];
 
   const chunks: string[] = [];
-  let current = '';
+  let current: string | null = null;
 
   const flush = () => {
-    if (current) {
+    if (current !== null) {
       chunks.push(current);
-      current = '';
+      current = null;
     }
   };
 
@@ -745,11 +773,12 @@ export function chunkForTelegram(message: string, maxLen = 4000): string[] {
       continue;
     }
 
-    if (current.length + line.length + 1 > maxLen) {
+    const candidate = current === null ? line : current + '\n' + line;
+    if (candidate.length > maxLen) {
       flush();
       current = line;
     } else {
-      current += (current ? '\n' : '') + line;
+      current = candidate;
     }
   }
   flush();

--- a/test/calendar-bot-test.ts
+++ b/test/calendar-bot-test.ts
@@ -14,6 +14,7 @@ import {
   formatHotListBlock,
   formatWeeklyDigest,
   hotFeedbackKeyboard,
+  parseHotFeedback,
   chunkForTelegram,
   createEvent,
   type CalendarBotConfig,
@@ -442,6 +443,37 @@ describe('test: calendar-bot module', () => {
       });
     });
 
+    describe('parseHotFeedback', () => {
+      it('parses helpful verdict with no event id', () => {
+        const out = parseHotFeedback('hot_feedback:helpful');
+        expect(out).to.deep.equal({ verdict: 'helpful', eventId: undefined, known: true });
+      });
+
+      it('parses not_useful verdict with no event id', () => {
+        const out = parseHotFeedback('hot_feedback:not_useful');
+        expect(out).to.deep.equal({ verdict: 'not_useful', eventId: undefined, known: true });
+      });
+
+      it('parses verdict + event id (forward-compat)', () => {
+        // Future format: `hot_feedback:<verdict>:<event_id>` for per-event scoring.
+        // Pre-fix the slice() approach treated 'helpful:abc-123' as one verdict
+        // and logged it as unknown.
+        const out = parseHotFeedback('hot_feedback:helpful:evt-abc-123');
+        expect(out).to.deep.equal({ verdict: 'helpful', eventId: 'evt-abc-123', known: true });
+      });
+
+      it('flags unknown verdicts so handler can warn instead of silently accepting', () => {
+        const out = parseHotFeedback('hot_feedback:lukewarm');
+        expect(out.verdict).to.equal('lukewarm');
+        expect(out.known).to.be.false;
+      });
+
+      it('returns known=false for unrecognized prefix', () => {
+        const out = parseHotFeedback('something_else:helpful');
+        expect(out.known).to.be.false;
+      });
+    });
+
     describe('hotFeedbackKeyboard', () => {
       it('returns inline keyboard with helpful and not_useful feedback buttons', () => {
         const keyboard = hotFeedbackKeyboard();
@@ -478,6 +510,16 @@ describe('test: calendar-bot module', () => {
         chunks.forEach(c => expect(c.length).to.be.lessThanOrEqual(100));
         // No content lost for unbroken input.
         expect(chunks.join('')).to.equal(message);
+      });
+
+      it('preserves leading and adjacent blank lines on round-trip', () => {
+        // Pre-fix bug: `current ? '\n' : ''` swallowed the leading newline
+        // because empty string was indistinguishable from "no current chunk".
+        const line = 'x'.repeat(50);
+        const message = `\n${line}\n\n${line}`;
+        const chunks = chunkForTelegram(message, 80);
+        expect(chunks.length).to.be.greaterThan(1);
+        expect(chunks.join('\n')).to.equal(message);
       });
     });
   });

--- a/test/calendar-bot-test.ts
+++ b/test/calendar-bot-test.ts
@@ -521,6 +521,22 @@ describe('test: calendar-bot module', () => {
         expect(chunks.length).to.be.greaterThan(1);
         expect(chunks.join('\n')).to.equal(message);
       });
+
+      it('keeps an overlong line and the next short line in separate chunks', () => {
+        // Each chunk is sent as its own Telegram message, so the original
+        // newline boundary between an overlong line and the next short line
+        // is preserved as a *message boundary*, not as a `\n` inside one
+        // chunk. Locking this in: an overlong line followed by a short line
+        // must produce at least one boundary that ends with the overlong
+        // line's tail and starts a fresh chunk for the short line.
+        const overlong = 'a'.repeat(150);
+        const message = `${overlong}\nshort`;
+        const chunks = chunkForTelegram(message, 100);
+        expect(chunks).to.have.lengthOf.at.least(2);
+        // Last chunk must be exactly the short line, not concatenated with
+        // any tail of the overlong line.
+        expect(chunks[chunks.length - 1]).to.equal('short');
+      });
     });
   });
 });

--- a/test/calendar-bot-test.ts
+++ b/test/calendar-bot-test.ts
@@ -470,6 +470,15 @@ describe('test: calendar-bot module', () => {
         // No content lost.
         expect(chunks.join('\n')).to.equal(message);
       });
+
+      it('hard-splits a single overlong line into bounded chunks', () => {
+        const message = 'x'.repeat(250);
+        const chunks = chunkForTelegram(message, 100);
+        expect(chunks.length).to.be.greaterThan(1);
+        chunks.forEach(c => expect(c.length).to.be.lessThanOrEqual(100));
+        // No content lost for unbroken input.
+        expect(chunks.join('')).to.equal(message);
+      });
     });
   });
 });

--- a/test/calendar-bot-test.ts
+++ b/test/calendar-bot-test.ts
@@ -14,6 +14,7 @@ import {
   formatHotListBlock,
   formatWeeklyDigest,
   hotFeedbackKeyboard,
+  chunkForTelegram,
   createEvent,
   type CalendarBotConfig,
   type CalendarEventDraft,
@@ -442,14 +443,32 @@ describe('test: calendar-bot module', () => {
     });
 
     describe('hotFeedbackKeyboard', () => {
-      it('returns inline keyboard with up and down feedback buttons', () => {
+      it('returns inline keyboard with helpful and not_useful feedback buttons', () => {
         const keyboard = hotFeedbackKeyboard();
         const buttons = keyboard.reply_markup.inline_keyboard.flat();
         expect(buttons).to.have.lengthOf(2);
-        // Each button has callback_data.
         const callbackData = buttons.map((b: { callback_data?: string }) => b.callback_data);
-        expect(callbackData).to.include('hot_feedback_up');
-        expect(callbackData).to.include('hot_feedback_down');
+        // Prefix `hot_feedback:` lets the handler dispatch generically and
+        // leaves room for `:event_id` suffix in a future iteration.
+        expect(callbackData).to.include('hot_feedback:helpful');
+        expect(callbackData).to.include('hot_feedback:not_useful');
+      });
+    });
+
+    describe('chunkForTelegram', () => {
+      it('returns single chunk when message fits limit', () => {
+        const out = chunkForTelegram('short message', 4000);
+        expect(out).to.deep.equal(['short message']);
+      });
+
+      it('splits on newlines when message exceeds limit', () => {
+        const line = 'x'.repeat(50);
+        const message = Array.from({ length: 5 }, () => line).join('\n');
+        const chunks = chunkForTelegram(message, 100);
+        expect(chunks.length).to.be.greaterThan(1);
+        chunks.forEach(c => expect(c.length).to.be.lessThanOrEqual(100));
+        // No content lost.
+        expect(chunks.join('\n')).to.equal(message);
       });
     });
   });

--- a/test/calendar-bot-test.ts
+++ b/test/calendar-bot-test.ts
@@ -10,9 +10,14 @@ import {
   apiUrl,
   fetchCategories,
   fetchUpcomingEvents,
+  fetchHotEvents,
+  formatHotListBlock,
+  formatWeeklyDigest,
+  hotFeedbackKeyboard,
   createEvent,
   type CalendarBotConfig,
   type CalendarEventDraft,
+  type CalendarEventResponse,
 } from '../bots/calendar-bot.ts';
 
 const testConfig: CalendarBotConfig = {
@@ -292,6 +297,159 @@ describe('test: calendar-bot module', () => {
         expect(requestBody.event).to.not.have.property('end_date');
         expect(requestBody.event).to.not.have.property('description');
         expect(requestBody.event).to.not.have.property('link');
+      });
+    });
+
+    // ==================== Hot list (Phase 1) ====================
+
+    describe('fetchHotEvents', () => {
+      it('hits the API with is_hot=true filter', async () => {
+        const fetchStub = sinon.stub(globalThis, 'fetch').resolves(
+          new Response(JSON.stringify({ events: [], total: 0 }), { status: 200 })
+        );
+
+        await fetchHotEvents(testConfig);
+
+        const calledUrl = fetchStub.firstCall.args[0] as string;
+        expect(calledUrl).to.include('is_hot=true');
+        expect(calledUrl).to.include('status=published');
+      });
+
+      it('returns empty result on network error', async () => {
+        sinon.stub(globalThis, 'fetch').rejects(new Error('boom'));
+
+        const result = await fetchHotEvents(testConfig);
+        expect(result.events).to.deep.equal([]);
+        expect(result.total).to.equal(0);
+      });
+    });
+
+    describe('formatHotListBlock', () => {
+      const baseEvent: CalendarEventResponse = {
+        id: '1',
+        name: 'FOMC Decision',
+        date: '2026-05-01',
+        time: '14:00',
+        end_date: null,
+        description: null,
+        link: null,
+        category: { name: 'Fed/Macro Events', slug: 'fed-macro' },
+      };
+
+      it('returns null when no hot events', () => {
+        const events = [{ ...baseEvent, is_hot: false }];
+        expect(formatHotListBlock(events)).to.be.null;
+      });
+
+      it('returns null when input is empty', () => {
+        expect(formatHotListBlock([])).to.be.null;
+      });
+
+      it('renders header + bullets only for hot events', () => {
+        const events: CalendarEventResponse[] = [
+          { ...baseEvent, id: '1', name: 'Hot one', is_hot: true, hot_reason: 'FOMC' },
+          { ...baseEvent, id: '2', name: 'Cold one', is_hot: false },
+          { ...baseEvent, id: '3', name: 'Hot two', is_hot: true },
+        ];
+
+        const block = formatHotListBlock(events)!;
+        expect(block).to.include('🔥 <b>Hot this week</b>');
+        expect(block).to.include('Hot one');
+        expect(block).to.include('Hot two');
+        expect(block).to.not.include('Cold one');
+      });
+
+      it('appends hot_reason after em-dash when present', () => {
+        const events: CalendarEventResponse[] = [
+          { ...baseEvent, name: 'Powell speaks', is_hot: true, hot_reason: 'Post-FOMC presser' },
+        ];
+
+        const block = formatHotListBlock(events)!;
+        expect(block).to.include('Powell speaks');
+        expect(block).to.include('Post-FOMC presser');
+      });
+
+      it('escapes HTML in event names and reasons', () => {
+        const events: CalendarEventResponse[] = [
+          {
+            ...baseEvent,
+            name: 'Evil <script>alert(1)</script>',
+            is_hot: true,
+            hot_reason: 'rogue & danger',
+          },
+        ];
+
+        const block = formatHotListBlock(events)!;
+        expect(block).to.not.include('<script>');
+        expect(block).to.include('&lt;script&gt;');
+        expect(block).to.include('rogue &amp; danger');
+      });
+    });
+
+    describe('formatWeeklyDigest', () => {
+      const cold: CalendarEventResponse = {
+        id: '1',
+        name: 'Routine Speech',
+        date: '2026-05-01',
+        time: null,
+        end_date: null,
+        description: null,
+        link: null,
+        category: { name: 'Fed/Macro Events', slug: 'fed-macro' },
+        is_hot: false,
+      };
+      const hot: CalendarEventResponse = {
+        ...cold,
+        id: '2',
+        name: 'Big Unlock',
+        is_hot: true,
+        hot_reason: 'Top unlock this week',
+        category: { name: 'Token Unlocks', slug: 'token-unlocks' },
+      };
+
+      it('emits the empty-state copy when no events', () => {
+        const out = formatWeeklyDigest({ events: [], total: 0 });
+        expect(out).to.include('No upcoming events');
+      });
+
+      it('puts the hot block above the upcoming list when hot events exist', () => {
+        const out = formatWeeklyDigest({ events: [cold, hot], total: 2 });
+        const hotIdx = out.indexOf('🔥 <b>Hot this week</b>');
+        const upcomingIdx = out.indexOf('Upcoming Events');
+        expect(hotIdx).to.be.greaterThan(-1);
+        expect(upcomingIdx).to.be.greaterThan(hotIdx);
+      });
+
+      it('omits the hot block entirely when no events are flagged', () => {
+        const out = formatWeeklyDigest({ events: [cold], total: 1 });
+        expect(out).to.not.include('Hot this week');
+        expect(out).to.include('Upcoming Events');
+      });
+
+      it('prefixes hot events in the upcoming list with the flame', () => {
+        const out = formatWeeklyDigest({ events: [hot, cold], total: 2 });
+        // The hot event line in the upcoming section should have a flame.
+        expect(out).to.include('🔥 📌 <b>Big Unlock</b>');
+        expect(out).to.include('📌 <b>Routine Speech</b>');
+        // Cold event should not be flame-prefixed.
+        expect(out).to.not.include('🔥 📌 <b>Routine Speech</b>');
+      });
+
+      it('shows showing X of Y footer when shown < total', () => {
+        const out = formatWeeklyDigest({ events: [cold], total: 5 });
+        expect(out).to.include('Showing 1 of 5 events');
+      });
+    });
+
+    describe('hotFeedbackKeyboard', () => {
+      it('returns inline keyboard with up and down feedback buttons', () => {
+        const keyboard = hotFeedbackKeyboard();
+        const buttons = keyboard.reply_markup.inline_keyboard.flat();
+        expect(buttons).to.have.lengthOf(2);
+        // Each button has callback_data.
+        const callbackData = buttons.map((b: { callback_data?: string }) => b.callback_data);
+        expect(callbackData).to.include('hot_feedback_up');
+        expect(callbackData).to.include('hot_feedback_down');
       });
     });
   });


### PR DESCRIPTION
## Summary
- New `/hotlist` command returns the next 7 days of curator-flagged hot events with reason and inline feedback buttons (helpful / not useful)
- `/upcoming` now renders via `formatWeeklyDigest`, which leads with a "🔥 Hot this week" block before the standard upcoming list — same shape the weekly digest job will emit once Hydra-side wiring lands
- Inline feedback callback uses prefix scheme `hot_feedback:<verdict>` and logs `[hot_feedback] user=<id> verdict=helpful|not_useful message_id=<msg>` — block-level for Phase 1; per-event scoring will land when we have engagement signal to tune on

## Why
Feeds the 2026-05 newsletter A/B test (curator-picked top events surfaced in the weekly digest) per the 2026-04-24 sync with Lindsay Poss. Starts collecting reader-side validation signal we'll need for Stage 2 (rules) and Stage 3 (LLM scoring).

## Scope (Phase 1 = manual only)
- `fetchHotEvents` — `GET /api/v1/calendar/events?is_hot=true&start_date=…&end_date=…`
- `formatHotListBlock` — markdown rendering with reason + flame, escapes HTML
- `formatWeeklyDigest` — prepends hot block, in-lines flame on hot events in the upcoming section, footer with shown/total
- `chunkForTelegram` — splits messages on newlines under the 4000-char Telegram limit
- `hotFeedbackKeyboard` — inline keyboard with `hot_feedback:helpful` / `hot_feedback:not_useful` callback data
- `/hotlist` slash command, `/upcoming` rewired through `formatWeeklyDigest`, `/start` and `/help` list the new command

## Test plan
- [x] `npm test` (59 passing)
- [ ] Manual: send `/hotlist` in dev TG, verify rendered block matches curator picks in `/admin/hot-list`
- [ ] Manual: send `/upcoming` and verify the hot block appears at the top
- [ ] Manual: tap feedback buttons, verify `[hot_feedback]` log line written

## Companion PRs
- Hydra: delphidigital/hydra#863 (schema + endpoint + audit)
- delphi-calendar-web: delphidigital/delphi-calendar-web#53 (curator UI + public flame)

🤖 Generated with [Claude Code](https://claude.com/claude-code)